### PR TITLE
chore: normalize repository url in package.json

### DIFF
--- a/.projenrc.js
+++ b/.projenrc.js
@@ -15,7 +15,7 @@ const project = new cdk.JsiiProject({
   ],
   name: 'cdk8s-image',
   description: 'Build & Push local docker images inside CDK8s applications',
-  repository: 'git@github.com:cdk8s-team/cdk8s-image.git',
+  repository: 'https://github.com/cdk8s-team/cdk8s-image',
   defaultReleaseBranch: 'main',
   projenUpgradeSecret: 'PROJEN_GITHUB_TOKEN',
   autoApproveOptions: {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Build & Push local docker images inside CDK8s applications",
   "repository": {
     "type": "git",
-    "url": "git@github.com:cdk8s-team/cdk8s-image.git"
+    "url": "https://github.com/cdk8s-team/cdk8s-image"
   },
   "scripts": {
     "build": "npx projen build",


### PR DESCRIPTION
Normalize the repository URL so that it renders normally on Construct Hub (see https://github.com/cdklabs/construct-hub/issues/666).